### PR TITLE
Fix arc fallback to max probability for missing scores

### DIFF
--- a/src/fabula/core.py
+++ b/src/fabula/core.py
@@ -64,13 +64,17 @@ class Fabula:
         if fallback_to_maxprob:
             mask = pd.isna(df[score_col])
             if bool(mask.any()):
+                probs_list = df["probs"].tolist()
                 raw_y = [
-                    (max(p.values()) if isinstance(p, dict) and len(p) else float("nan"))
-                    for p in df["probs"].tolist()
+                    (
+                        max(p.values())
+                        if missing and isinstance(p, dict) and len(p)
+                        else y
+                    )
+                    for y, p, missing in zip(raw_y, probs_list, mask.tolist())
                 ]
 
         x_rs, y_rs = resample_to_n(raw_x, raw_y, n_points=n_points)
         y_sm = smooth_moving_average(y_rs, window=smooth_window)
 
         return ArcResult(x=x_rs, y=y_sm, raw_x=raw_x, raw_y=raw_y)
-


### PR DESCRIPTION
### Motivation
- The `arc` method previously replaced all `score` values with max-probability fallbacks when `fallback_to_maxprob` was enabled, clobbering existing non-missing scores.
- The intent is to only fill in missing `score` entries from the per-segment `probs` rather than overwrite valid scores.

### Description
- Updated `src/fabula/core.py` inside `Fabula.arc` to compute `probs_list` and only substitute max-probability values where the `score` is missing by using `mask` and `zip(raw_y, probs_list, mask.tolist())`.
- Preserved existing `raw_y` values for non-missing scores and only filled entries where `pd.isna(df[score_col])` is true.
- The change keeps the downstream resampling and smoothing logic (`resample_to_n`, `smooth_moving_average`) and returns an unchanged `ArcResult` shape.