### PR TITLE
Add emotion analysis option and CLI support

### DIFF
--- a/tests/test_core_smoke.py
+++ b/tests/test_core_smoke.py
@@ -9,6 +9,13 @@ class DummyScorer:
     def predict_proba(self, texts: Sequence[str]) -> List[Dict[str, float]]:
         return [{"POSITIVE": 0.6, "NEGATIVE": 0.4} for _ in texts]
 
+
+@dataclass
+class EmotionDummyScorer:
+    def predict_proba(self, texts: Sequence[str]) -> List[Dict[str, float]]:
+        return [{"JOIE": 0.2, "TRISTESSE": 0.8} for _ in texts]
+
+
 def test_fabula_score_and_arc():
     f = Fabula(scorer=DummyScorer())
     df = f.score("Bonjour. Triste.")
@@ -19,3 +26,8 @@ def test_fabula_score_and_arc():
     assert len(arc.x) == 10
     assert len(arc.y) == 10
 
+
+def test_fabula_emotion_scores():
+    f = Fabula(scorer=EmotionDummyScorer(), analysis="emotion")
+    df = f.score("Bonjour. Triste.")
+    assert df["score"].iloc[0] == 0.8


### PR DESCRIPTION
### Motivation
- Enable two analysis modes so narrative scoring can run either sentiment or emotion analysis.
- Provide a sensible default model selection for each analysis type, including support for `astrosbd` for emotion.
- Make the CLI and dummy scorer aware of the chosen analysis to allow local smoke testing without transformers.

### Description
- Add an `analysis` field to `Fabula`, validate allowed types in `_ANALYSIS_TYPES`, and implement `_score_from_probs` to compute sentiment (`valence_from_probs`) or emotion (top probability) scores.
- Extend the CLI with `--analysis` and a `DEFAULT_MODELS` map, add `_resolve_model` to choose the model (defaults to `cmarkea/distilcamembert-base-sentiment` or `astrosbd`), and propagate `analysis` into scorer/`Fabula` creation.
- Make the dummy scorer accept an `analysis` argument and emit emotion-style probability dictionaries for smoke tests.
- Add `test_fabula_emotion_scores` to `tests/test_core_smoke.py` to assert emotion scoring behavior.

### Testing
- Ran `pytest -q` and all tests passed.
- Test run: `6 passed in 5.44s`.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_695fdf14ca6083229fa970a451b6b212)