### PR TITLE
Add configurable smoothing options for narrative arcs

### DIFF
--- a/src/fabula/arc.py
+++ b/src/fabula/arc.py
@@ -31,13 +31,70 @@ def resample_to_n(x: Sequence[float], y: Sequence[float], n_points: int = 100) -
     return xs.tolist(), ys.tolist()
 
 
-def smooth_moving_average(y: Sequence[float], window: int = 7) -> List[float]:
+def smooth_moving_average(y: Sequence[float], window: int = 7, pad_mode: str = "reflect") -> List[float]:
     y_arr = np.asarray(y, dtype=float)
     if window <= 1 or len(y_arr) == 0:
         return y_arr.tolist()
 
     window = int(min(window, len(y_arr)))
+    if window % 2 == 0:
+        window += 1
+
     kernel = np.ones(window, dtype=float) / float(window)
-    ys = np.convolve(y_arr, kernel, mode="same")
+    ys = _convolve_with_padding(y_arr, kernel, pad_mode=pad_mode)
     return ys.tolist()
 
+
+def smooth_gaussian(y: Sequence[float], window: int = 7, sigma: float | None = None, pad_mode: str = "reflect") -> List[float]:
+    y_arr = np.asarray(y, dtype=float)
+    if window <= 1 or len(y_arr) == 0:
+        return y_arr.tolist()
+
+    window = int(min(window, len(y_arr)))
+    if window % 2 == 0:
+        window += 1
+
+    if sigma is None or sigma <= 0:
+        sigma = max(window / 6.0, 1e-6)
+
+    half = window // 2
+    x = np.arange(-half, half + 1, dtype=float)
+    kernel = np.exp(-0.5 * (x / sigma) ** 2)
+    kernel = kernel / kernel.sum()
+
+    ys = _convolve_with_padding(y_arr, kernel, pad_mode=pad_mode)
+    return ys.tolist()
+
+
+def smooth_series(
+    y: Sequence[float],
+    method: str = "moving_average",
+    window: int = 7,
+    sigma: float | None = None,
+    pad_mode: str = "reflect",
+) -> List[float]:
+    method = method.lower()
+    if method in {"none", "raw"}:
+        return list(np.asarray(y, dtype=float))
+    if method in {"moving_average", "mean", "ma"}:
+        return smooth_moving_average(y, window=window, pad_mode=pad_mode)
+    if method in {"gaussian", "gauss"}:
+        return smooth_gaussian(y, window=window, sigma=sigma, pad_mode=pad_mode)
+    raise ValueError(f"Unknown smoothing method: {method}")
+
+
+def _convolve_with_padding(y_arr: np.ndarray, kernel: np.ndarray, pad_mode: str = "reflect") -> np.ndarray:
+    pad = len(kernel) // 2
+    if pad <= 0:
+        return y_arr
+
+    pad_kwargs = {}
+    if pad_mode == "constant":
+        pad_kwargs["constant_values"] = 0.0
+
+    try:
+        padded = np.pad(y_arr, pad_width=pad, mode=pad_mode, **pad_kwargs)
+    except ValueError as e:
+        raise ValueError(f"Unsupported pad_mode: {pad_mode}") from e
+
+    return np.convolve(padded, kernel, mode="valid")

--- a/src/fabula/cli.py
+++ b/src/fabula/cli.py
@@ -166,6 +166,9 @@ def cmd_arc(args: argparse.Namespace) -> int:
         text,
         n_points=args.n_points,
         smooth_window=args.smooth_window,
+        smooth_method=args.smooth_method,
+        smooth_sigma=args.smooth_sigma,
+        smooth_pad_mode=args.smooth_pad_mode,
         score_col=args.score_col,
         fallback_to_maxprob=args.fallback_to_maxprob,
     )
@@ -237,7 +240,25 @@ def build_parser() -> argparse.ArgumentParser:
     add_common(sp_arc)
     sp_arc.add_argument("--format", choices=["csv", "json"], default="csv", help="Output format.")
     sp_arc.add_argument("--n-points", type=int, default=100, help="Resample the arc to N points.")
-    sp_arc.add_argument("--smooth-window", type=int, default=9, help="Moving average window size.")
+    sp_arc.add_argument("--smooth-window", type=int, default=9, help="Smoothing window size.")
+    sp_arc.add_argument(
+        "--smooth-method",
+        choices=["moving_average", "gaussian", "none"],
+        default="moving_average",
+        help="Smoothing method (default: moving_average).",
+    )
+    sp_arc.add_argument(
+        "--smooth-sigma",
+        type=float,
+        default=None,
+        help="Gaussian sigma (default: window/6). Only used with --smooth-method=gaussian.",
+    )
+    sp_arc.add_argument(
+        "--smooth-pad-mode",
+        choices=["reflect", "edge", "constant"],
+        default="reflect",
+        help="Padding mode for smoothing (default: reflect).",
+    )
     sp_arc.add_argument("--score-col", default="score", help="Column to use as scalar score.")
     sp_arc.add_argument("--no-fallback-to-maxprob", dest="fallback_to_maxprob", action="store_false",
                         help="Disable fallback scalar using max(prob) when score is missing.")

--- a/src/fabula/core.py
+++ b/src/fabula/core.py
@@ -5,7 +5,7 @@ from typing import Any, Dict, List, Optional
 
 import pandas as pd
 
-from .arc import resample_to_n, smooth_moving_average
+from .arc import resample_to_n, smooth_series
 from .schemas import ArcResult
 from .scorer import TransformersScorer, valence_from_probs
 from .segment import RegexSentenceSegmenter
@@ -62,6 +62,9 @@ class Fabula:
         text: str,
         n_points: int = 100,
         smooth_window: int = 7,
+        smooth_method: str = "moving_average",
+        smooth_sigma: Optional[float] = None,
+        smooth_pad_mode: str = "reflect",
         score_col: str = "score",
         fallback_to_maxprob: bool = True,
     ) -> ArcResult:
@@ -87,6 +90,12 @@ class Fabula:
                 ]
 
         x_rs, y_rs = resample_to_n(raw_x, raw_y, n_points=n_points)
-        y_sm = smooth_moving_average(y_rs, window=smooth_window)
+        y_sm = smooth_series(
+            y_rs,
+            method=smooth_method,
+            window=smooth_window,
+            sigma=smooth_sigma,
+            pad_mode=smooth_pad_mode,
+        )
 
         return ArcResult(x=x_rs, y=y_sm, raw_x=raw_x, raw_y=raw_y)


### PR DESCRIPTION
- Added `smooth_gaussian`, `smooth_series`, and `_convolve_with_padding` to `src/fabula/arc.py`, and updated `smooth_moving_average` to use padding-aware convolution and enforce an odd window size.
- Implemented Gaussian kernel construction with a default `sigma = window/6.0` and normalized kernel application via `_convolve_with_padding` that supports `reflect`, `edge`, and `constant` pad modes.
- Updated `Fabula.arc()` in `src/fabula/core.py` to accept `smooth_method`, `smooth_sigma`, and `smooth_pad_mode` parameters and to call `smooth_series` instead of the old moving-average helper.
- Exposed the new options in the CLI (`--smooth-method`, `--smooth-sigma`, `--smooth-pad-mode`) and updated the `--smooth-window` help text in `src/fabula/cli.py`.