### PR TITLE
Add calibration and uncertainty controls for narrative arcs

### DIFF
--- a/src/fabula/arc.py
+++ b/src/fabula/arc.py
@@ -31,13 +31,70 @@ def resample_to_n(x: Sequence[float], y: Sequence[float], n_points: int = 100) -
     return xs.tolist(), ys.tolist()
 
 
-def smooth_moving_average(y: Sequence[float], window: int = 7) -> List[float]:
+def smooth_moving_average(y: Sequence[float], window: int = 7, pad_mode: str = "reflect") -> List[float]:
     y_arr = np.asarray(y, dtype=float)
     if window <= 1 or len(y_arr) == 0:
         return y_arr.tolist()
 
     window = int(min(window, len(y_arr)))
+    if window % 2 == 0:
+        window += 1
+
     kernel = np.ones(window, dtype=float) / float(window)
-    ys = np.convolve(y_arr, kernel, mode="same")
+    ys = _convolve_with_padding(y_arr, kernel, pad_mode=pad_mode)
     return ys.tolist()
 
+
+def smooth_gaussian(y: Sequence[float], window: int = 7, sigma: float | None = None, pad_mode: str = "reflect") -> List[float]:
+    y_arr = np.asarray(y, dtype=float)
+    if window <= 1 or len(y_arr) == 0:
+        return y_arr.tolist()
+
+    window = int(min(window, len(y_arr)))
+    if window % 2 == 0:
+        window += 1
+
+    if sigma is None or sigma <= 0:
+        sigma = max(window / 6.0, 1e-6)
+
+    half = window // 2
+    x = np.arange(-half, half + 1, dtype=float)
+    kernel = np.exp(-0.5 * (x / sigma) ** 2)
+    kernel = kernel / kernel.sum()
+
+    ys = _convolve_with_padding(y_arr, kernel, pad_mode=pad_mode)
+    return ys.tolist()
+
+
+def smooth_series(
+    y: Sequence[float],
+    method: str = "moving_average",
+    window: int = 7,
+    sigma: float | None = None,
+    pad_mode: str = "reflect",
+) -> List[float]:
+    method = method.lower()
+    if method in {"none", "raw"}:
+        return list(np.asarray(y, dtype=float))
+    if method in {"moving_average", "mean", "ma"}:
+        return smooth_moving_average(y, window=window, pad_mode=pad_mode)
+    if method in {"gaussian", "gauss"}:
+        return smooth_gaussian(y, window=window, sigma=sigma, pad_mode=pad_mode)
+    raise ValueError(f"Unknown smoothing method: {method}")
+
+
+def _convolve_with_padding(y_arr: np.ndarray, kernel: np.ndarray, pad_mode: str = "reflect") -> np.ndarray:
+    pad = len(kernel) // 2
+    if pad <= 0:
+        return y_arr
+
+    pad_kwargs = {}
+    if pad_mode == "constant":
+        pad_kwargs["constant_values"] = 0.0
+
+    try:
+        padded = np.pad(y_arr, pad_width=pad, mode=pad_mode, **pad_kwargs)
+    except ValueError as e:
+        raise ValueError(f"Unsupported pad_mode: {pad_mode}") from e
+
+    return np.convolve(padded, kernel, mode="valid")

--- a/src/fabula/cli.py
+++ b/src/fabula/cli.py
@@ -77,10 +77,22 @@ def _df_to_jsonl(df: pd.DataFrame) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _load_transformers_scorer(model: str, device: Optional[str], batch_size: int, max_length: int):
+def _load_transformers_scorer(
+    model: str,
+    device: Optional[str],
+    batch_size: int,
+    max_length: int,
+    temperature: float,
+):
     # import lazily so CLI can run in dummy mode without transformers installed
     from .scorer import TransformersScorer
-    return TransformersScorer(model=model, device=device, batch_size=batch_size, max_length=max_length)
+    return TransformersScorer(
+        model=model,
+        device=device,
+        batch_size=batch_size,
+        max_length=max_length,
+        temperature=temperature,
+    )
 
 
 def _make_segmenter(kind: str, scorer_or_none, window_tokens: int, stride_tokens: int, min_tokens: int):
@@ -115,6 +127,7 @@ def cmd_score(args: argparse.Namespace) -> int:
         device=args.device,
         batch_size=args.batch_size,
         max_length=args.max_length,
+        temperature=args.temperature,
     )
 
     segmenter = _make_segmenter(
@@ -151,6 +164,7 @@ def cmd_arc(args: argparse.Namespace) -> int:
         device=args.device,
         batch_size=args.batch_size,
         max_length=args.max_length,
+        temperature=args.temperature,
     )
 
     segmenter = _make_segmenter(
@@ -166,6 +180,12 @@ def cmd_arc(args: argparse.Namespace) -> int:
         text,
         n_points=args.n_points,
         smooth_window=args.smooth_window,
+        smooth_method=args.smooth_method,
+        smooth_sigma=args.smooth_sigma,
+        smooth_pad_mode=args.smooth_pad_mode,
+        uncertainty_samples=args.uncertainty_samples,
+        uncertainty_ci=args.uncertainty_ci,
+        uncertainty_concentration=args.uncertainty_concentration,
         score_col=args.score_col,
         fallback_to_maxprob=args.fallback_to_maxprob,
     )
@@ -173,9 +193,16 @@ def cmd_arc(args: argparse.Namespace) -> int:
     fmt = args.format.lower()
     if fmt == "csv":
         out_df = pd.DataFrame({"x": arc.x, "y": arc.y})
+        if arc.y_low is not None and arc.y_high is not None:
+            out_df["y_low"] = arc.y_low
+            out_df["y_high"] = arc.y_high
         content = out_df.to_csv(index=False)
     elif fmt == "json":
-        content = json.dumps({"x": arc.x, "y": arc.y, "raw_x": arc.raw_x, "raw_y": arc.raw_y}, ensure_ascii=False)
+        payload = {"x": arc.x, "y": arc.y, "raw_x": arc.raw_x, "raw_y": arc.raw_y}
+        if arc.y_low is not None and arc.y_high is not None:
+            payload["y_low"] = arc.y_low
+            payload["y_high"] = arc.y_high
+        content = json.dumps(payload, ensure_ascii=False)
     else:
         raise ValueError(f"Unsupported format: {args.format}")
 
@@ -221,6 +248,12 @@ def build_parser() -> argparse.ArgumentParser:
         sp.add_argument("--device", default=None, help="cpu, cuda, cuda:0 (default: auto).")
         sp.add_argument("--batch-size", type=int, default=16, help="Batch size for inference.")
         sp.add_argument("--max-length", type=int, default=512, help="Max tokens per segment fed to the model.")
+        sp.add_argument(
+            "--temperature",
+            type=float,
+            default=1.0,
+            help="Softmax temperature for probability calibration (default: 1.0).",
+        )
 
         sp.add_argument("--segment", choices=["sentence", "paragraph", "window"], default="sentence",
                         help="Segmentation strategy (default: sentence).")
@@ -237,7 +270,43 @@ def build_parser() -> argparse.ArgumentParser:
     add_common(sp_arc)
     sp_arc.add_argument("--format", choices=["csv", "json"], default="csv", help="Output format.")
     sp_arc.add_argument("--n-points", type=int, default=100, help="Resample the arc to N points.")
-    sp_arc.add_argument("--smooth-window", type=int, default=9, help="Moving average window size.")
+    sp_arc.add_argument("--smooth-window", type=int, default=9, help="Smoothing window size.")
+    sp_arc.add_argument(
+        "--smooth-method",
+        choices=["moving_average", "gaussian", "none"],
+        default="moving_average",
+        help="Smoothing method (default: moving_average).",
+    )
+    sp_arc.add_argument(
+        "--smooth-sigma",
+        type=float,
+        default=None,
+        help="Gaussian sigma (default: window/6). Only used with --smooth-method=gaussian.",
+    )
+    sp_arc.add_argument(
+        "--smooth-pad-mode",
+        choices=["reflect", "edge", "constant"],
+        default="reflect",
+        help="Padding mode for smoothing (default: reflect).",
+    )
+    sp_arc.add_argument(
+        "--uncertainty-samples",
+        type=int,
+        default=0,
+        help="Number of Monte Carlo samples for uncertainty bands (default: 0).",
+    )
+    sp_arc.add_argument(
+        "--uncertainty-ci",
+        type=float,
+        default=0.95,
+        help="Confidence interval for uncertainty bands (default: 0.95).",
+    )
+    sp_arc.add_argument(
+        "--uncertainty-concentration",
+        type=float,
+        default=50.0,
+        help="Dirichlet concentration for sampling from probabilities (default: 50.0).",
+    )
     sp_arc.add_argument("--score-col", default="score", help="Column to use as scalar score.")
     sp_arc.add_argument("--no-fallback-to-maxprob", dest="fallback_to_maxprob", action="store_false",
                         help="Disable fallback scalar using max(prob) when score is missing.")

--- a/src/fabula/core.py
+++ b/src/fabula/core.py
@@ -4,8 +4,9 @@ from dataclasses import dataclass
 from typing import Any, Dict, List, Optional
 
 import pandas as pd
+import numpy as np
 
-from .arc import resample_to_n, smooth_moving_average
+from .arc import resample_to_n, smooth_series
 from .schemas import ArcResult
 from .scorer import TransformersScorer, valence_from_probs
 from .segment import RegexSentenceSegmenter
@@ -62,6 +63,12 @@ class Fabula:
         text: str,
         n_points: int = 100,
         smooth_window: int = 7,
+        smooth_method: str = "moving_average",
+        smooth_sigma: Optional[float] = None,
+        smooth_pad_mode: str = "reflect",
+        uncertainty_samples: int = 0,
+        uncertainty_ci: float = 0.95,
+        uncertainty_concentration: float = 50.0,
         score_col: str = "score",
         fallback_to_maxprob: bool = True,
     ) -> ArcResult:
@@ -87,6 +94,86 @@ class Fabula:
                 ]
 
         x_rs, y_rs = resample_to_n(raw_x, raw_y, n_points=n_points)
-        y_sm = smooth_moving_average(y_rs, window=smooth_window)
+        y_sm = smooth_series(
+            y_rs,
+            method=smooth_method,
+            window=smooth_window,
+            sigma=smooth_sigma,
+            pad_mode=smooth_pad_mode,
+        )
 
-        return ArcResult(x=x_rs, y=y_sm, raw_x=raw_x, raw_y=raw_y)
+        y_low = None
+        y_high = None
+        if uncertainty_samples > 0:
+            if not (0.0 < uncertainty_ci < 1.0):
+                raise ValueError("uncertainty_ci must be between 0 and 1")
+            if uncertainty_concentration <= 0:
+                raise ValueError("uncertainty_concentration must be > 0")
+
+            samples = _sample_scores(
+                df=df,
+                analysis=self.analysis,
+                score_col=score_col,
+                fallback_to_maxprob=fallback_to_maxprob,
+                n_samples=uncertainty_samples,
+                concentration=uncertainty_concentration,
+            )
+            arc_samples = []
+            for ys in samples:
+                x_s, y_s = resample_to_n(raw_x, ys, n_points=n_points)
+                y_s = smooth_series(
+                    y_s,
+                    method=smooth_method,
+                    window=smooth_window,
+                    sigma=smooth_sigma,
+                    pad_mode=smooth_pad_mode,
+                )
+                arc_samples.append(y_s)
+
+            arr = np.asarray(arc_samples, dtype=float)
+            alpha = (1.0 - uncertainty_ci) / 2.0
+            y_low = np.quantile(arr, alpha, axis=0).tolist()
+            y_high = np.quantile(arr, 1.0 - alpha, axis=0).tolist()
+
+        return ArcResult(x=x_rs, y=y_sm, raw_x=raw_x, raw_y=raw_y, y_low=y_low, y_high=y_high)
+
+
+def _sample_scores(
+    df: pd.DataFrame,
+    analysis: str,
+    score_col: str,
+    fallback_to_maxprob: bool,
+    n_samples: int,
+    concentration: float,
+) -> List[List[float]]:
+    rng = np.random.default_rng()
+    probs_list = df["probs"].tolist()
+    raw_scores = df[score_col].astype(float).tolist()
+
+    samples: List[List[float]] = [[] for _ in range(n_samples)]
+    for probs, raw_score in zip(probs_list, raw_scores):
+        if isinstance(probs, dict) and len(probs):
+            labels = list(probs.keys())
+            p = np.array([float(probs[k]) for k in labels], dtype=float)
+            if p.sum() <= 0:
+                p = np.ones_like(p) / float(len(p))
+            else:
+                p = p / p.sum()
+            alpha = p * concentration
+            draw = rng.dirichlet(alpha, size=n_samples)
+            for i in range(n_samples):
+                sample_probs = {label: float(draw[i][j]) for j, label in enumerate(labels)}
+                if analysis == "sentiment":
+                    score = valence_from_probs(sample_probs)
+                else:
+                    score = max(sample_probs.values()) if sample_probs else None
+                samples[i].append(float(score) if score is not None else float("nan"))
+        else:
+            if fallback_to_maxprob and isinstance(probs, dict) and len(probs):
+                value = float(max(probs.values()))
+            else:
+                value = float(raw_score) if not pd.isna(raw_score) else float("nan")
+            for i in range(n_samples):
+                samples[i].append(value)
+
+    return samples

--- a/src/fabula/schemas.py
+++ b/src/fabula/schemas.py
@@ -28,4 +28,5 @@ class ArcResult:
     y: List[float]       # smoothed scores
     raw_x: List[float]   # raw segment positions
     raw_y: List[float]   # raw segment scores
-
+    y_low: Optional[List[float]] = None   # lower CI bound if computed
+    y_high: Optional[List[float]] = None  # upper CI bound if computed


### PR DESCRIPTION
- Add `temperature` to `TransformersScorer` and apply it to logits in `predict_proba` with validation in `__post_init__` (must be `> 0`).
- Add Monte Carlo sampling via a new `_sample_scores` helper and expose `uncertainty_samples`, `uncertainty_ci`, and `uncertainty_concentration` in `Fabula.arc`, returning CI bounds as `ArcResult.y_low` and `ArcResult.y_high`.
- Introduce smoothing utilities (`smooth_series`, `smooth_gaussian`, `smooth_moving_average`, and `_convolve_with_padding`) and parameterize smoothing with `--smooth-method`, `--smooth-sigma`, and `--smooth-pad-mode` used by `arc`.
- Update the CLI to accept `--temperature`, `--uncertainty-*` flags and to emit `y_low`/`y_high` in CSV and JSON arc outputs when available.
