### PR TITLE
Add `transformers-sp` extra and document SentencePiece installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,3 +2,25 @@
 A Python package to study the evolution of a narration through sentiment and emotion analysis. 
 
 Implementation for French language for now.
+
+## Installation
+Base install:
+
+```bash
+pip install fabula
+```
+
+Transformers support:
+
+```bash
+pip install fabula[transformers]
+```
+
+Some Hugging Face models require SentencePiece. If you see an error about missing
+`sentencepiece`, install the extra below or add the package directly:
+
+```bash
+pip install fabula[transformers-sp]
+# or
+pip install sentencepiece
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,6 +17,7 @@ dependencies = [
 
 [project.optional-dependencies]
 transformers = ["transformers>=4.40", "torch"]
+transformers-sp = ["transformers>=4.40", "torch", "sentencepiece"]
 dev = ["pytest>=7", "ruff>=0.5"]
 plot = ["matplotlib"]
 
@@ -28,4 +29,3 @@ line-length = 100
 
 [project.scripts]
 fabula = "fabula.cli:main"
-


### PR DESCRIPTION
### Response to Issue "sentencepiece"
- Some Hugging Face transformer models require `sentencepiece`, which can cause runtime errors if missing. 
- The project needs clear installation instructions for base and transformer-backed features. 
- Adding an extra that bundles `sentencepiece` allows users to install required deps with a single `pip` command. 

### Description
- Updated `README.md` to add an "Installation" section with examples for `pip install fabula`, `pip install fabula[transformers]`, and `pip install fabula[transformers-sp]`.
- Added a note in `README.md` recommending `pip install fabula[transformers-sp]` or `pip install sentencepiece` when a missing `sentencepiece` error occurs.
- Added a `transformers-sp` optional dependency in `pyproject.toml` that includes `transformers`, `torch`, and `sentencepiece`.