### PR TITLE
Add pooled chunk scoring and document chunk segmenter

### DIFF
--- a/src/fabula/cli.py
+++ b/src/fabula/cli.py
@@ -10,7 +10,12 @@ from typing import Dict, List, Optional, Sequence, Tuple
 import pandas as pd
 
 from .core import Fabula
-from .segment import ParagraphSegmenter, RegexSentenceSegmenter, SlidingWindowTokenSegmenter
+from .segment import (
+    DocumentChunkTokenSegmenter,
+    ParagraphSegmenter,
+    RegexSentenceSegmenter,
+    SlidingWindowTokenSegmenter,
+)
 
 
 DEFAULT_MODELS = {
@@ -77,17 +82,40 @@ def _df_to_jsonl(df: pd.DataFrame) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _load_transformers_scorer(model: str, device: Optional[str], batch_size: int, max_length: int):
+def _load_transformers_scorer(
+    model: str,
+    device: Optional[str],
+    batch_size: int,
+    max_length: int,
+    pooling: str,
+    pooling_stride_tokens: Optional[int],
+):
     # import lazily so CLI can run in dummy mode without transformers installed
     from .scorer import TransformersScorer
-    return TransformersScorer(model=model, device=device, batch_size=batch_size, max_length=max_length)
+    return TransformersScorer(
+        model=model,
+        device=device,
+        batch_size=batch_size,
+        max_length=max_length,
+        pooling=pooling,
+        pooling_stride_tokens=pooling_stride_tokens,
+    )
 
 
-def _make_segmenter(kind: str, scorer_or_none, window_tokens: int, stride_tokens: int, min_tokens: int):
+def _make_segmenters(
+    kind: str,
+    scorer_or_none,
+    window_tokens: int,
+    stride_tokens: int,
+    min_tokens: int,
+    chunk_tokens: int,
+    chunk_stride_tokens: int,
+    chunk_min_tokens: int,
+) -> Tuple[object, Optional[object]]:
     if kind == "sentence":
-        return RegexSentenceSegmenter()
+        return RegexSentenceSegmenter(), None
     if kind == "paragraph":
-        return ParagraphSegmenter()
+        return ParagraphSegmenter(), None
     if kind == "window":
         if scorer_or_none is None or getattr(scorer_or_none, "tokenizer", None) is None:
             raise ValueError("Window segmentation requires a transformers tokenizer (disable --dummy).")
@@ -96,6 +124,15 @@ def _make_segmenter(kind: str, scorer_or_none, window_tokens: int, stride_tokens
             window_tokens=window_tokens,
             stride_tokens=stride_tokens,
             min_tokens=min_tokens,
+        ), None
+    if kind == "document":
+        if scorer_or_none is None or getattr(scorer_or_none, "tokenizer", None) is None:
+            raise ValueError("Document chunking requires a transformers tokenizer (disable --dummy).")
+        return RegexSentenceSegmenter(), DocumentChunkTokenSegmenter(
+            tokenizer=scorer_or_none.tokenizer,
+            chunk_tokens=chunk_tokens,
+            stride_tokens=chunk_stride_tokens,
+            min_tokens=chunk_min_tokens,
         )
     raise ValueError(f"Unknown segmenter kind: {kind}")
 
@@ -115,17 +152,29 @@ def cmd_score(args: argparse.Namespace) -> int:
         device=args.device,
         batch_size=args.batch_size,
         max_length=args.max_length,
+        pooling=args.pooling,
+        pooling_stride_tokens=args.pooling_stride_tokens,
     )
 
-    segmenter = _make_segmenter(
+    segmenter, coarse_segmenter = _make_segmenters(
         kind=args.segment,
         scorer_or_none=None if args.dummy else scorer,
         window_tokens=args.window_tokens,
         stride_tokens=args.stride_tokens,
         min_tokens=args.min_tokens,
+        chunk_tokens=args.chunk_tokens,
+        chunk_stride_tokens=args.chunk_stride_tokens,
+        chunk_min_tokens=args.chunk_min_tokens,
     )
 
-    fb = Fabula(scorer=scorer, segmenter=segmenter, analysis=args.analysis)
+    fb = Fabula(
+        scorer=scorer,
+        segmenter=segmenter,
+        coarse_segmenter=coarse_segmenter,
+        analysis=args.analysis,
+        chunk_weight=args.chunk_weight,
+        chunk_attention_tau=args.chunk_attention_tau,
+    )
     df = fb.score(text)
 
     fmt = args.format.lower()
@@ -151,17 +200,29 @@ def cmd_arc(args: argparse.Namespace) -> int:
         device=args.device,
         batch_size=args.batch_size,
         max_length=args.max_length,
+        pooling=args.pooling,
+        pooling_stride_tokens=args.pooling_stride_tokens,
     )
 
-    segmenter = _make_segmenter(
+    segmenter, coarse_segmenter = _make_segmenters(
         kind=args.segment,
         scorer_or_none=None if args.dummy else scorer,
         window_tokens=args.window_tokens,
         stride_tokens=args.stride_tokens,
         min_tokens=args.min_tokens,
+        chunk_tokens=args.chunk_tokens,
+        chunk_stride_tokens=args.chunk_stride_tokens,
+        chunk_min_tokens=args.chunk_min_tokens,
     )
 
-    fb = Fabula(scorer=scorer, segmenter=segmenter, analysis=args.analysis)
+    fb = Fabula(
+        scorer=scorer,
+        segmenter=segmenter,
+        coarse_segmenter=coarse_segmenter,
+        analysis=args.analysis,
+        chunk_weight=args.chunk_weight,
+        chunk_attention_tau=args.chunk_attention_tau,
+    )
     arc = fb.arc(
         text,
         n_points=args.n_points,
@@ -224,12 +285,25 @@ def build_parser() -> argparse.ArgumentParser:
         sp.add_argument("--device", default=None, help="cpu, cuda, cuda:0 (default: auto).")
         sp.add_argument("--batch-size", type=int, default=16, help="Batch size for inference.")
         sp.add_argument("--max-length", type=int, default=512, help="Max tokens per segment fed to the model.")
+        sp.add_argument("--pooling", choices=["none", "mean", "max", "attention"], default="none",
+                        help="Chunk-level pooling for long inputs (default: none).")
+        sp.add_argument("--pooling-stride-tokens", type=int, default=None,
+                        help="Stride for pooled chunking (default: max_length/4).")
 
-        sp.add_argument("--segment", choices=["sentence", "paragraph", "window"], default="sentence",
+        sp.add_argument("--segment", choices=["sentence", "paragraph", "window", "document"], default="sentence",
                         help="Segmentation strategy (default: sentence).")
         sp.add_argument("--window-tokens", type=int, default=256, help="Token window size (segment=window).")
         sp.add_argument("--stride-tokens", type=int, default=64, help="Token stride (segment=window).")
         sp.add_argument("--min-tokens", type=int, default=16, help="Min tokens for window segments.")
+        sp.add_argument("--chunk-tokens", type=int, default=1024, help="Chunk token size (segment=document).")
+        sp.add_argument("--chunk-stride-tokens", type=int, default=1024,
+                        help="Chunk stride (segment=document).")
+        sp.add_argument("--chunk-min-tokens", type=int, default=128,
+                        help="Min tokens for document chunks (segment=document).")
+        sp.add_argument("--chunk-weight", type=float, default=0.3,
+                        help="Interpolation weight for chunk scores (segment=document).")
+        sp.add_argument("--chunk-attention-tau", type=float, default=0.1,
+                        help="Attention pooling temperature for chunks (segment=document).")
 
     sp_score = sub.add_parser("score", help="Score segments and output per-segment data.")
     add_common(sp_score)

--- a/src/fabula/scorer.py
+++ b/src/fabula/scorer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, Iterable, List, Optional, Sequence
 
 
 @dataclass
@@ -15,6 +15,8 @@ class TransformersScorer:
     device: Optional[str] = None  # "cpu", "cuda", "cuda:0"
     batch_size: int = 16
     max_length: int = 512
+    pooling: str = "none"  # none, mean, max, attention
+    pooling_stride_tokens: Optional[int] = None
 
     def __post_init__(self):
         try:
@@ -41,11 +43,77 @@ class TransformersScorer:
         cfg = getattr(self.model_obj, "config", None)
         id2label = getattr(cfg, "id2label", None) if cfg is not None else None
         self.id2label = {int(k): v for k, v in id2label.items()} if isinstance(id2label, dict) else None
+        if self.pooling not in {"none", "mean", "max", "attention"}:
+            raise ValueError("pooling must be one of: none, mean, max, attention.")
+        if self.pooling_stride_tokens is not None and self.pooling_stride_tokens <= 0:
+            raise ValueError("pooling_stride_tokens must be positive.")
+
+    def _row_to_dict(self, row: Iterable[float]) -> Dict[str, float]:
+        d: Dict[str, float] = {}
+        for j, p in enumerate(row):
+            label = self.id2label.get(j, str(j)) if self.id2label else str(j)
+            d[label] = float(p)
+        return d
+
+    def _pool_chunk_probs(self, probs: List[List[float]]) -> List[float]:
+        if not probs:
+            return []
+        if self.pooling == "mean":
+            n = len(probs)
+            return [sum(row[i] for row in probs) / n for i in range(len(probs[0]))]
+        if self.pooling == "max":
+            return [max(row[i] for row in probs) for i in range(len(probs[0]))]
+        if self.pooling == "attention":
+            import math
+            weights = [max(row) for row in probs]
+            max_w = max(weights)
+            exp_w = [math.exp(w - max_w) for w in weights]
+            norm = sum(exp_w) or 1.0
+            exp_w = [w / norm for w in exp_w]
+            return [
+                sum(w * row[i] for w, row in zip(exp_w, probs))
+                for i in range(len(probs[0]))
+            ]
+        return probs[0]
+
+    def _predict_batch_probs(self, enc) -> List[List[float]]:
+        torch = self.torch
+        probs_list: List[List[float]] = []
+        self.model_obj.eval()
+        with torch.no_grad():
+            for i in range(0, enc["input_ids"].shape[0], self.batch_size):
+                batch = {k: v[i:i + self.batch_size].to(self.device) for k, v in enc.items()}
+                logits = self.model_obj(**batch).logits
+                probs = torch.softmax(logits, dim=-1).detach().cpu().numpy()
+                probs_list.extend(probs.tolist())
+        return probs_list
+
+    def _predict_with_pooling(self, text: str) -> Dict[str, float]:
+        stride = self.pooling_stride_tokens
+        if stride is None:
+            stride = max(1, self.max_length // 4)
+        enc = self.tokenizer(
+            text,
+            padding=True,
+            truncation=True,
+            max_length=self.max_length,
+            return_overflowing_tokens=True,
+            stride=stride,
+            return_tensors="pt",
+        )
+        probs_list = self._predict_batch_probs(enc)
+        pooled = self._pool_chunk_probs(probs_list)
+        return self._row_to_dict(pooled)
 
     def predict_proba(self, texts: Sequence[str]) -> List[Dict[str, float]]:
         torch = self.torch
         texts = list(texts)
         results: List[Dict[str, float]] = []
+
+        if self.pooling != "none":
+            for text in texts:
+                results.append(self._predict_with_pooling(text))
+            return results
 
         self.model_obj.eval()
         with torch.no_grad():
@@ -63,11 +131,7 @@ class TransformersScorer:
                 probs = torch.softmax(logits, dim=-1).detach().cpu().numpy()
 
                 for row in probs:
-                    d: Dict[str, float] = {}
-                    for j, p in enumerate(row):
-                        label = self.id2label.get(j, str(j)) if self.id2label else str(j)
-                        d[label] = float(p)
-                    results.append(d)
+                    results.append(self._row_to_dict(row))
 
         return results
 
@@ -92,4 +156,3 @@ def valence_from_probs(probs: Dict[str, float]) -> Optional[float]:
         return get("positive") - get("negative")
 
     return None
-


### PR DESCRIPTION
### Motivation
- Support scoring of long inputs by pooling per-chunk model probabilities instead of truncating long text into a single model call.
- Expose configurable pooling strategies so different aggregation behaviors (mean/max/attention) can be experimented with from the CLI.
- Provide document-level chunking that reports coarse chunk probabilities and aligns chunks to character offsets for blending with fine-grained segment predictions.
- Allow blending of coarse (chunk) and fine (segment) probabilities using attention-weighted pooling for better context-aware scores.

### Description
- Add pooling options to `TransformersScorer` including `pooling` (`none|mean|max|attention`) and `pooling_stride_tokens`, implement chunked overflow token inference (`return_overflowing_tokens`) and pooling helpers `_pool_chunk_probs`, `_predict_batch_probs`, and `_predict_with_pooling` to aggregate chunk probabilities. 
- Wire CLI flags `--pooling` and `--pooling-stride-tokens` into scorer construction and handle pooled prediction paths in `predict_proba`. 
- Add `DocumentChunkTokenSegmenter` which chunks a document using tokenizer offsets and decodes chunks while tracking token and character positions for alignment. 
- Extend `Fabula` to accept `coarse_segmenter`, perform attention-weighted pooling of chunk probabilities (`_attention_pool_probs`), blend chunk and fine-grained probabilities (`_blend_probs`), and include `chunk_probs` and blended `probs` in per-segment outputs. 
