### PR TITLE
Add document chunking, pooling support and tests

### DIFF
--- a/src/fabula/cli.py
+++ b/src/fabula/cli.py
@@ -10,7 +10,12 @@ from typing import Dict, List, Optional, Sequence, Tuple
 import pandas as pd
 
 from .core import Fabula
-from .segment import ParagraphSegmenter, RegexSentenceSegmenter, SlidingWindowTokenSegmenter
+from .segment import (
+    DocumentChunkTokenSegmenter,
+    ParagraphSegmenter,
+    RegexSentenceSegmenter,
+    SlidingWindowTokenSegmenter,
+)
 
 
 DEFAULT_MODELS = {
@@ -77,17 +82,40 @@ def _df_to_jsonl(df: pd.DataFrame) -> str:
     return "\n".join(lines) + "\n"
 
 
-def _load_transformers_scorer(model: str, device: Optional[str], batch_size: int, max_length: int):
+def _load_transformers_scorer(
+    model: str,
+    device: Optional[str],
+    batch_size: int,
+    max_length: int,
+    pooling: str,
+    pooling_stride_tokens: Optional[int],
+):
     # import lazily so CLI can run in dummy mode without transformers installed
     from .scorer import TransformersScorer
-    return TransformersScorer(model=model, device=device, batch_size=batch_size, max_length=max_length)
+    return TransformersScorer(
+        model=model,
+        device=device,
+        batch_size=batch_size,
+        max_length=max_length,
+        pooling=pooling,
+        pooling_stride_tokens=pooling_stride_tokens,
+    )
 
 
-def _make_segmenter(kind: str, scorer_or_none, window_tokens: int, stride_tokens: int, min_tokens: int):
+def _make_segmenters(
+    kind: str,
+    scorer_or_none,
+    window_tokens: int,
+    stride_tokens: int,
+    min_tokens: int,
+    chunk_tokens: int,
+    chunk_stride_tokens: int,
+    chunk_min_tokens: int,
+) -> Tuple[object, Optional[object]]:
     if kind == "sentence":
-        return RegexSentenceSegmenter()
+        return RegexSentenceSegmenter(), None
     if kind == "paragraph":
-        return ParagraphSegmenter()
+        return ParagraphSegmenter(), None
     if kind == "window":
         if scorer_or_none is None or getattr(scorer_or_none, "tokenizer", None) is None:
             raise ValueError("Window segmentation requires a transformers tokenizer (disable --dummy).")
@@ -96,6 +124,15 @@ def _make_segmenter(kind: str, scorer_or_none, window_tokens: int, stride_tokens
             window_tokens=window_tokens,
             stride_tokens=stride_tokens,
             min_tokens=min_tokens,
+        ), None
+    if kind == "document":
+        if scorer_or_none is None or getattr(scorer_or_none, "tokenizer", None) is None:
+            raise ValueError("Document chunking requires a transformers tokenizer (disable --dummy).")
+        return RegexSentenceSegmenter(), DocumentChunkTokenSegmenter(
+            tokenizer=scorer_or_none.tokenizer,
+            chunk_tokens=chunk_tokens,
+            stride_tokens=chunk_stride_tokens,
+            min_tokens=chunk_min_tokens,
         )
     raise ValueError(f"Unknown segmenter kind: {kind}")
 
@@ -115,17 +152,29 @@ def cmd_score(args: argparse.Namespace) -> int:
         device=args.device,
         batch_size=args.batch_size,
         max_length=args.max_length,
+        pooling=args.pooling,
+        pooling_stride_tokens=args.pooling_stride_tokens,
     )
 
-    segmenter = _make_segmenter(
+    segmenter, coarse_segmenter = _make_segmenters(
         kind=args.segment,
         scorer_or_none=None if args.dummy else scorer,
         window_tokens=args.window_tokens,
         stride_tokens=args.stride_tokens,
         min_tokens=args.min_tokens,
+        chunk_tokens=args.chunk_tokens,
+        chunk_stride_tokens=args.chunk_stride_tokens,
+        chunk_min_tokens=args.chunk_min_tokens,
     )
 
-    fb = Fabula(scorer=scorer, segmenter=segmenter, analysis=args.analysis)
+    fb = Fabula(
+        scorer=scorer,
+        segmenter=segmenter,
+        coarse_segmenter=coarse_segmenter,
+        analysis=args.analysis,
+        chunk_weight=args.chunk_weight,
+        chunk_attention_tau=args.chunk_attention_tau,
+    )
     df = fb.score(text)
 
     fmt = args.format.lower()
@@ -151,17 +200,29 @@ def cmd_arc(args: argparse.Namespace) -> int:
         device=args.device,
         batch_size=args.batch_size,
         max_length=args.max_length,
+        pooling=args.pooling,
+        pooling_stride_tokens=args.pooling_stride_tokens,
     )
 
-    segmenter = _make_segmenter(
+    segmenter, coarse_segmenter = _make_segmenters(
         kind=args.segment,
         scorer_or_none=None if args.dummy else scorer,
         window_tokens=args.window_tokens,
         stride_tokens=args.stride_tokens,
         min_tokens=args.min_tokens,
+        chunk_tokens=args.chunk_tokens,
+        chunk_stride_tokens=args.chunk_stride_tokens,
+        chunk_min_tokens=args.chunk_min_tokens,
     )
 
-    fb = Fabula(scorer=scorer, segmenter=segmenter, analysis=args.analysis)
+    fb = Fabula(
+        scorer=scorer,
+        segmenter=segmenter,
+        coarse_segmenter=coarse_segmenter,
+        analysis=args.analysis,
+        chunk_weight=args.chunk_weight,
+        chunk_attention_tau=args.chunk_attention_tau,
+    )
     arc = fb.arc(
         text,
         n_points=args.n_points,
@@ -224,12 +285,25 @@ def build_parser() -> argparse.ArgumentParser:
         sp.add_argument("--device", default=None, help="cpu, cuda, cuda:0 (default: auto).")
         sp.add_argument("--batch-size", type=int, default=16, help="Batch size for inference.")
         sp.add_argument("--max-length", type=int, default=512, help="Max tokens per segment fed to the model.")
+        sp.add_argument("--pooling", choices=["none", "mean", "max", "attention"], default="none",
+                        help="Chunk-level pooling for long inputs (default: none).")
+        sp.add_argument("--pooling-stride-tokens", type=int, default=None,
+                        help="Stride for pooled chunking (default: max_length/4).")
 
-        sp.add_argument("--segment", choices=["sentence", "paragraph", "window"], default="sentence",
+        sp.add_argument("--segment", choices=["sentence", "paragraph", "window", "document"], default="sentence",
                         help="Segmentation strategy (default: sentence).")
         sp.add_argument("--window-tokens", type=int, default=256, help="Token window size (segment=window).")
         sp.add_argument("--stride-tokens", type=int, default=64, help="Token stride (segment=window).")
         sp.add_argument("--min-tokens", type=int, default=16, help="Min tokens for window segments.")
+        sp.add_argument("--chunk-tokens", type=int, default=1024, help="Chunk token size (segment=document).")
+        sp.add_argument("--chunk-stride-tokens", type=int, default=1024,
+                        help="Chunk stride (segment=document).")
+        sp.add_argument("--chunk-min-tokens", type=int, default=128,
+                        help="Min tokens for document chunks (segment=document).")
+        sp.add_argument("--chunk-weight", type=float, default=0.3,
+                        help="Interpolation weight for chunk scores (segment=document).")
+        sp.add_argument("--chunk-attention-tau", type=float, default=0.1,
+                        help="Attention pooling temperature for chunks (segment=document).")
 
     sp_score = sub.add_parser("score", help="Score segments and output per-segment data.")
     add_common(sp_score)

--- a/src/fabula/scorer.py
+++ b/src/fabula/scorer.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List, Optional, Sequence
+from typing import Dict, Iterable, List, Optional, Sequence
 
 
 @dataclass
@@ -15,6 +15,8 @@ class TransformersScorer:
     device: Optional[str] = None  # "cpu", "cuda", "cuda:0"
     batch_size: int = 16
     max_length: int = 512
+    pooling: str = "none"  # none, mean, max, attention
+    pooling_stride_tokens: Optional[int] = None
 
     def __post_init__(self):
         try:
@@ -41,11 +43,77 @@ class TransformersScorer:
         cfg = getattr(self.model_obj, "config", None)
         id2label = getattr(cfg, "id2label", None) if cfg is not None else None
         self.id2label = {int(k): v for k, v in id2label.items()} if isinstance(id2label, dict) else None
+        if self.pooling not in {"none", "mean", "max", "attention"}:
+            raise ValueError("pooling must be one of: none, mean, max, attention.")
+        if self.pooling_stride_tokens is not None and self.pooling_stride_tokens <= 0:
+            raise ValueError("pooling_stride_tokens must be positive.")
+
+    def _row_to_dict(self, row: Iterable[float]) -> Dict[str, float]:
+        d: Dict[str, float] = {}
+        for j, p in enumerate(row):
+            label = self.id2label.get(j, str(j)) if self.id2label else str(j)
+            d[label] = float(p)
+        return d
+
+    def _pool_chunk_probs(self, probs: List[List[float]]) -> List[float]:
+        if not probs:
+            return []
+        if self.pooling == "mean":
+            n = len(probs)
+            return [sum(row[i] for row in probs) / n for i in range(len(probs[0]))]
+        if self.pooling == "max":
+            return [max(row[i] for row in probs) for i in range(len(probs[0]))]
+        if self.pooling == "attention":
+            import math
+            weights = [max(row) for row in probs]
+            max_w = max(weights)
+            exp_w = [math.exp(w - max_w) for w in weights]
+            norm = sum(exp_w) or 1.0
+            exp_w = [w / norm for w in exp_w]
+            return [
+                sum(w * row[i] for w, row in zip(exp_w, probs))
+                for i in range(len(probs[0]))
+            ]
+        return probs[0]
+
+    def _predict_batch_probs(self, enc) -> List[List[float]]:
+        torch = self.torch
+        probs_list: List[List[float]] = []
+        self.model_obj.eval()
+        with torch.no_grad():
+            for i in range(0, enc["input_ids"].shape[0], self.batch_size):
+                batch = {k: v[i:i + self.batch_size].to(self.device) for k, v in enc.items()}
+                logits = self.model_obj(**batch).logits
+                probs = torch.softmax(logits, dim=-1).detach().cpu().numpy()
+                probs_list.extend(probs.tolist())
+        return probs_list
+
+    def _predict_with_pooling(self, text: str) -> Dict[str, float]:
+        stride = self.pooling_stride_tokens
+        if stride is None:
+            stride = max(1, self.max_length // 4)
+        enc = self.tokenizer(
+            text,
+            padding=True,
+            truncation=True,
+            max_length=self.max_length,
+            return_overflowing_tokens=True,
+            stride=stride,
+            return_tensors="pt",
+        )
+        probs_list = self._predict_batch_probs(enc)
+        pooled = self._pool_chunk_probs(probs_list)
+        return self._row_to_dict(pooled)
 
     def predict_proba(self, texts: Sequence[str]) -> List[Dict[str, float]]:
         torch = self.torch
         texts = list(texts)
         results: List[Dict[str, float]] = []
+
+        if self.pooling != "none":
+            for text in texts:
+                results.append(self._predict_with_pooling(text))
+            return results
 
         self.model_obj.eval()
         with torch.no_grad():
@@ -63,11 +131,7 @@ class TransformersScorer:
                 probs = torch.softmax(logits, dim=-1).detach().cpu().numpy()
 
                 for row in probs:
-                    d: Dict[str, float] = {}
-                    for j, p in enumerate(row):
-                        label = self.id2label.get(j, str(j)) if self.id2label else str(j)
-                        d[label] = float(p)
-                    results.append(d)
+                    results.append(self._row_to_dict(row))
 
         return results
 
@@ -92,4 +156,3 @@ def valence_from_probs(probs: Dict[str, float]) -> Optional[float]:
         return get("positive") - get("negative")
 
     return None
-

--- a/tests/test_core_smoke.py
+++ b/tests/test_core_smoke.py
@@ -3,6 +3,7 @@ from dataclasses import dataclass
 from typing import Dict, List, Sequence
 
 from fabula.core import Fabula
+from fabula.schemas import Segment
 
 @dataclass
 class DummyScorer:
@@ -14,6 +15,25 @@ class DummyScorer:
 class EmotionDummyScorer:
     def predict_proba(self, texts: Sequence[str]) -> List[Dict[str, float]]:
         return [{"JOIE": 0.2, "TRISTESSE": 0.8} for _ in texts]
+
+@dataclass
+class VariedDummyScorer:
+    def predict_proba(self, texts: Sequence[str]) -> List[Dict[str, float]]:
+        out = []
+        for text in texts:
+            if "chunk" in text:
+                out.append({"POSITIVE": 0.1, "NEGATIVE": 0.9})
+            else:
+                out.append({"POSITIVE": 0.9, "NEGATIVE": 0.1})
+        return out
+
+
+class StaticSegmenter:
+    def __init__(self, segments: List[Segment]) -> None:
+        self._segments = segments
+
+    def segment(self, text: str) -> List[Segment]:
+        return self._segments
 
 
 def test_fabula_score_and_arc():
@@ -31,3 +51,25 @@ def test_fabula_emotion_scores():
     f = Fabula(scorer=EmotionDummyScorer(), analysis="emotion")
     df = f.score("Bonjour. Triste.")
     assert df["score"].iloc[0] == 0.8
+
+
+def test_fabula_chunk_blending():
+    fine_segments = [
+        Segment(idx=0, text="fine one", rel_pos=0.1),
+        Segment(idx=1, text="fine two", rel_pos=0.9),
+    ]
+    coarse_segments = [
+        Segment(idx=0, text="chunk one", rel_pos=0.0),
+        Segment(idx=1, text="chunk two", rel_pos=1.0),
+    ]
+    f = Fabula(
+        scorer=VariedDummyScorer(),
+        segmenter=StaticSegmenter(fine_segments),
+        coarse_segmenter=StaticSegmenter(coarse_segments),
+        chunk_weight=0.5,
+        chunk_attention_tau=1.0,
+    )
+    df = f.score("ignored")
+    assert "chunk_probs" in df.columns
+    assert df["chunk_probs"].iloc[0]["NEGATIVE"] > 0.1
+    assert df["score"].iloc[0] is not None

--- a/tests/test_scorer_pooling.py
+++ b/tests/test_scorer_pooling.py
@@ -1,0 +1,37 @@
+import pytest
+
+from fabula.scorer import TransformersScorer
+
+
+def _make_scorer(pooling: str) -> TransformersScorer:
+    scorer = TransformersScorer.__new__(TransformersScorer)
+    scorer.pooling = pooling
+    return scorer
+
+
+def test_pool_chunk_probs_mean():
+    scorer = _make_scorer("mean")
+    probs = [[0.2, 0.8], [0.6, 0.4]]
+    pooled = scorer._pool_chunk_probs(probs)
+    assert pooled == pytest.approx([0.4, 0.6])
+
+
+def test_pool_chunk_probs_max():
+    scorer = _make_scorer("max")
+    probs = [[0.2, 0.8], [0.6, 0.4]]
+    pooled = scorer._pool_chunk_probs(probs)
+    assert pooled == [0.6, 0.8]
+
+
+def test_pool_chunk_probs_attention():
+    scorer = _make_scorer("attention")
+    probs = [[0.9, 0.1], [0.2, 0.8]]
+    pooled = scorer._pool_chunk_probs(probs)
+    assert pooled[0] > pooled[1]
+
+
+def test_pool_chunk_probs_none():
+    scorer = _make_scorer("none")
+    probs = [[0.2, 0.8], [0.6, 0.4]]
+    pooled = scorer._pool_chunk_probs(probs)
+    assert pooled == [0.2, 0.8]

--- a/tests/test_segment.py
+++ b/tests/test_segment.py
@@ -1,4 +1,24 @@
-from fabula.segment import ParagraphSegmenter, RegexSentenceSegmenter
+from fabula.segment import DocumentChunkTokenSegmenter, ParagraphSegmenter, RegexSentenceSegmenter
+
+
+class DummyTokenizer:
+    def __call__(self, text, add_special_tokens=False, return_attention_mask=False, return_offsets_mapping=False,
+                 return_tensors=None):
+        tokens = text.split()
+        offsets = []
+        cursor = 0
+        for token in tokens:
+            start = text.index(token, cursor)
+            end = start + len(token)
+            offsets.append((start, end))
+            cursor = end
+        data = {"input_ids": list(range(len(tokens)))}
+        if return_offsets_mapping:
+            data["offset_mapping"] = offsets
+        return data
+
+    def decode(self, ids, skip_special_tokens=True, clean_up_tokenization_spaces=True):
+        return " ".join([f"tok{idx}" for idx in ids])
 
 def test_paragraph_segmenter():
     seg = ParagraphSegmenter()
@@ -14,3 +34,13 @@ def test_sentence_segmenter():
     out = seg.segment(text)
     assert len(out) >= 2
 
+
+def test_document_chunk_segmenter_offsets():
+    tokenizer = DummyTokenizer()
+    seg = DocumentChunkTokenSegmenter(tokenizer=tokenizer, chunk_tokens=3, stride_tokens=3, min_tokens=1)
+    text = "one two three four five six"
+    out = seg.segment(text)
+    assert len(out) == 2
+    assert out[0].start_char == 0
+    assert out[0].end_char == len("one two three")
+    assert out[1].start_char == len("one two three") + 1


### PR DESCRIPTION
### Motivation
- Support scoring of long documents by pooling per-chunk model probabilities instead of truncating inputs to a single model call.
- Expose configurable pooling strategies (`none|mean|max|attention`) and pooling stride to experiment with aggregation behavior.
- Provide coarse-grained document chunking aligned to character offsets so chunk scores can be blended with fine-grained segments.
- Blend coarse (chunk) and fine (segment) probabilities with attention-weighted pooling for context-aware per-segment scores.

### Description
- Add pooling options to `TransformersScorer` (`pooling`, `pooling_stride_tokens`) and implement helpers `_pool_chunk_probs`, `_predict_batch_probs`, and `_predict_with_pooling` to aggregate chunk-level probabilities for long texts.
- Add `DocumentChunkTokenSegmenter` that chunks a document using tokenizer offsets and decodes chunks while tracking token and character positions for alignment.
- Extend `Fabula` to accept `coarse_segmenter` and perform attention-weighted pooling (`_attention_pool_probs`) and blending (`_blend_probs`) of coarse and fine probabilities, and include `chunk_probs` and blended `probs` in outputs.
- Wire CLI flags into scorer/segmenter construction including `--pooling`, `--pooling-stride-tokens`, document chunking flags, and chunk blending parameters so the new functionality is available from the CLI.

### Testing
- Added unit tests `tests/test_scorer_pooling.py` for the pooling strategies, `tests/test_segment.py` for document chunk offsets, and extended `tests/test_core_smoke.py` to validate coarse/fine blending.
- Ran `pytest -q` against the test suite and all tests passed (`12 passed`).
- Floating-point equality in the mean-pooling test was relaxed using `pytest.approx` to avoid spurious failures.
- Tests exercise pooling logic without requiring the `transformers` package by instantiating scorer internals and using a dummy tokenizer/segmenter where appropriate.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69610edbfbf88322bde3bb3e76592973)