### PR TITLE
Add publication-ready arc plotting helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,12 +171,23 @@ fabula arc my.txt \
 
 ### Plotting
 
-The CLI can optionally plot the arc if matplotlib is installed.
+The CLI can optionally plot the arc if matplotlib is installed. For quick teaching visuals,
+use `--plot-raw` to show the underlying segment scores alongside the smoothed curve.
 
 ```bash
 fabula arc my.txt --plot arc.png
 # or show interactively
 fabula arc my.txt --plot -
+fabula arc my.txt --plot arc.png --plot-raw
+```
+
+You can also create plots programmatically:
+
+```python
+from fabula import Fabula, plot_arc
+
+arc = Fabula().arc(\"...\")
+plot_arc(arc, subtitle=\"Chapter 1: Opening scene\", raw_points=True, save_path=\"arc.png\")
 ```
 
 ## Output formats

--- a/src/fabula/__init__.py
+++ b/src/fabula/__init__.py
@@ -2,6 +2,7 @@ from .core import Fabula
 from .scorer import TransformersScorer
 from .segment import ParagraphSegmenter, RegexSentenceSegmenter, SlidingWindowTokenSegmenter
 from .schemas import ArcResult
+from .plot import plot_arc
 
 __all__ = [
     "Fabula",
@@ -10,5 +11,5 @@ __all__ = [
     "RegexSentenceSegmenter",
     "SlidingWindowTokenSegmenter",
     "ArcResult",
+    "plot_arc",
 ]
-

--- a/src/fabula/cli.py
+++ b/src/fabula/cli.py
@@ -246,21 +246,14 @@ def cmd_arc(args: argparse.Namespace) -> int:
     _write_text(args.output, content)
 
     if args.plot is not None:
-        try:
-            import matplotlib.pyplot as plt
-        except Exception as e:
-            raise ImportError("Plotting requires matplotlib (pip install fabula[plot]).") from e
+        from .plot import plot_arc
 
-        plt.figure()
-        plt.plot(arc.x, arc.y)
-        plt.xlabel("Relative position")
-        plt.ylabel("Score")
-        plt.title("Fabula arc")
-
-        if args.plot == "-":
-            plt.show()
-        else:
-            plt.savefig(args.plot, bbox_inches="tight")
+        plot_arc(
+            arc,
+            raw_points=args.plot_raw,
+            show=args.plot == "-",
+            save_path=None if args.plot == "-" else args.plot,
+        )
 
     return 0
 
@@ -338,6 +331,8 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Disable fallback scalar using max(prob) when score is missing.")
     sp_arc.add_argument("--plot", default=None,
                         help="Plot to a file (e.g., arc.png) or '-' to display interactively (requires matplotlib).")
+    sp_arc.add_argument("--plot-raw", action="store_true",
+                        help="Plot raw segment scores as points (requires --plot).")
     sp_arc.set_defaults(func=cmd_arc)
 
     return p

--- a/src/fabula/plot.py
+++ b/src/fabula/plot.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+from typing import Optional, Tuple
+
+from .schemas import ArcResult
+
+
+def plot_arc(
+    arc: ArcResult,
+    *,
+    title: str = "Fabula arc",
+    subtitle: Optional[str] = None,
+    xlabel: str = "Relative position",
+    ylabel: str = "Score",
+    figure_size: Tuple[float, float] = (8.0, 4.5),
+    line_color: str = "#2E6F9E",
+    fill_color: str = "#D5E5F2",
+    raw_points: bool = False,
+    raw_point_color: str = "#4D4D4D",
+    zero_line: bool = True,
+    save_path: Optional[str] = None,
+    show: bool = False,
+):
+    """Plot a narrative arc with publication-friendly defaults.
+
+    Parameters
+    ----------
+    arc:
+        Narrative arc output from :meth:`Fabula.arc`.
+    title, subtitle:
+        Title text displayed at the top of the chart.
+    xlabel, ylabel:
+        Axis labels.
+    figure_size:
+        Figure size in inches.
+    line_color, fill_color:
+        Colors used for the curve and the filled area.
+    raw_points:
+        When True, plot the raw segment scores as points.
+    zero_line:
+        Whether to draw a horizontal zero baseline.
+    save_path:
+        When provided, save the plot to this path.
+    show:
+        Whether to display the plot interactively.
+
+    Returns
+    -------
+    (fig, ax)
+        Matplotlib figure and axes.
+    """
+    import matplotlib.pyplot as plt
+
+    fig, ax = plt.subplots(figsize=figure_size)
+    ax.plot(arc.x, arc.y, color=line_color, linewidth=2.5)
+    ax.fill_between(arc.x, arc.y, 0.0, color=fill_color, alpha=0.75)
+
+    if raw_points and arc.raw_x and arc.raw_y:
+        ax.scatter(
+            arc.raw_x,
+            arc.raw_y,
+            color=raw_point_color,
+            s=20,
+            alpha=0.7,
+            zorder=3,
+            label="segments",
+        )
+
+    if zero_line:
+        ax.axhline(0.0, color="#666666", linewidth=1.0, linestyle="--", alpha=0.6)
+
+    ax.set_xlim(0.0, 1.0)
+    ax.set_xlabel(xlabel)
+    ax.set_ylabel(ylabel)
+    ax.set_title(title, loc="left", fontweight="bold")
+
+    if subtitle:
+        ax.text(
+            0.0,
+            1.02,
+            subtitle,
+            transform=ax.transAxes,
+            ha="left",
+            va="bottom",
+            fontsize=10,
+            color="#4D4D4D",
+        )
+
+    ax.grid(axis="y", alpha=0.25, linestyle="-")
+    ax.spines["top"].set_visible(False)
+    ax.spines["right"].set_visible(False)
+
+    if raw_points:
+        ax.legend(frameon=False, loc="upper right")
+
+    fig.tight_layout()
+
+    if save_path:
+        fig.savefig(save_path, bbox_inches="tight")
+    if show:
+        plt.show()
+
+    return fig, ax


### PR DESCRIPTION
### Motivation
- Plotting is important for clear visuals aimed at a DH audience, and the CLI's existing plotting was minimal and embedded inline.  
- Provide a reusable, publication-friendly plotting helper to produce cleaner charts for teaching and presentation.  
- Allow users to visualize both the smoothed arc and the underlying segment scores for pedagogical use.  

### Description
- Add `plot_arc` in `src/fabula/plot.py` that renders a publication-style arc with optional `raw_points` and save/show controls.  
- Export `plot_arc` from the package by adding it to `src/fabula/__init__.py`.  
- Wire the CLI `cmd_arc` to call `plot_arc` and add a `--plot-raw` flag to control raw segment point plotting.  
- Update `README.md` with CLI examples and a programmatic usage snippet showing `plot_arc`.  