### PR TITLE
Add vector arc support for multi-dimensional scores

### DIFF
--- a/src/fabula/plot.py
+++ b/src/fabula/plot.py
@@ -52,6 +52,9 @@ def plot_arc(
     import matplotlib.pyplot as plt
 
     fig, ax = plt.subplots(figsize=figure_size)
+    if arc.y is None:
+        raise ValueError("plot_arc only supports scalar arcs. Use arc.y_series for multi-dimensional output.")
+
     ax.plot(arc.x, arc.y, color=line_color, linewidth=2.5)
     ax.fill_between(arc.x, arc.y, 0.0, color=fill_color, alpha=0.75)
 

--- a/src/fabula/schemas.py
+++ b/src/fabula/schemas.py
@@ -25,7 +25,8 @@ class ScoredSegment(Segment):
 @dataclass(frozen=True)
 class ArcResult:
     x: List[float]       # resampled positions in [0, 1]
-    y: List[float]       # smoothed scores
+    y: Optional[List[float]]  # smoothed scalar scores
     raw_x: List[float]   # raw segment positions
-    raw_y: List[float]   # raw segment scores
-
+    raw_y: Optional[List[float]]  # raw scalar segment scores
+    y_series: Optional[Dict[str, List[float]]] = None  # smoothed vector scores
+    raw_y_series: Optional[Dict[str, List[float]]] = None  # raw vector scores


### PR DESCRIPTION
### Motivation
- Enable multi-dimensional narrative arcs so per-label or multi-column scores (e.g., emotion probabilities) can be produced and exported.
- Allow callers to request vector arcs from explicit columns or from the `probs` column that contains per-label probabilities.
- Preserve existing scalar arc behavior and CLI/plot UX while adding vector support.
- Prevent accidental plotting of multi-dimensional arcs via an explicit guard in `plot_arc`.

### Description
- Updated `ArcResult` to make scalar `y`/`raw_y` optional and to add `y_series` and `raw_y_series` for smoothed/raw vector outputs.
- Extended `Fabula.arc` to accept `score_cols` and to expand `probs` into per-label series, resample each series with `resample_to_n`, and smooth with `smooth_series` before returning vector results.
- Updated CLI to add `--score-cols`, pass `score_cols` into `arc`, and emit multi-column CSV/JSON payloads when `y_series` is present.
- Updated `plot_arc` to raise when given a vector arc (i.e., when `arc.y is None`) so callers must handle multi-dimensional plotting explicitly.

### Testing
- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6962071f39f48322bc80ed9d413c4d0d)