### PR TITLE
Make plotting and SentencePiece core dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,7 @@ Base install:
 pip install fabula
 ```
 
-Transformers support (required for real models):
-
-```bash
-pip install fabula[transformers]
-```
-
-Some Hugging Face models require SentencePiece:
-
-```bash
-pip install fabula[transformers-sp]
-# or
-pip install sentencepiece
-```
-
-Optional plotting support:
-
-```bash
-pip install fabula[plot]
-```
+Base install includes Transformers + Torch for model inference, plus SentencePiece and matplotlib.
 
 ## Quickstart
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,13 +13,14 @@ authors = [{ name = "Florian Cafiero and Alexandre Lionnet" }]
 dependencies = [
   "numpy",
   "pandas",
+  "matplotlib",
+  "sentencepiece",
+  "transformers>=4.40",
+  "torch",
 ]
 
 [project.optional-dependencies]
-transformers = ["transformers>=4.40", "torch"]
-transformers-sp = ["transformers>=4.40", "torch", "sentencepiece"]
 dev = ["pytest>=7", "ruff>=0.5"]
-plot = ["matplotlib"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/fabula"]


### PR DESCRIPTION
### Motivation

- The base install should include plotting and SentencePiece so users get plotting and common tokenizer support by default.
- `transformers` and `torch` were already promoted to core, but `matplotlib` and `sentencepiece` remained optional causing an inconsistent default experience.
- Simplify installation and reduce optional extras so the package is useful out of the box.

### Description

- Add `matplotlib` and `sentencepiece` to `dependencies` in `pyproject.toml` and remove the `plot` and `transformers-sp` optional extras.
- Keep `transformers>=4.40` and `torch` as core dependencies in `pyproject.toml`.
- Update the installation guidance in `README.md` to state the base install includes Transformers, Torch, SentencePiece, and matplotlib.
- Remove redundant optional extras entries from `pyproject.toml`.

### Testing

- No automated tests were run for this change because it only updates packaging and documentation.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_696211321e44832287e88d2adbb565b9)