### PR TITLE
Add sampling controls for token explanations

### DIFF
--- a/src/fabula/cli.py
+++ b/src/fabula/cli.py
@@ -48,6 +48,16 @@ class DummyScorer:
                     out.append({"POSITIVE": 0.7, "NEGATIVE": 0.3})
         return out
 
+    def explain_tokens(
+        self,
+        text: str,
+        target_label: Optional[str] = None,
+        top_k: Optional[int] = None,
+        max_tokens: Optional[int] = None,
+        stride: Optional[int] = None,
+    ) -> List[Dict[str, object]]:
+        return []
+
 
 def _read_text(input_path: str, encoding: str = "utf-8") -> str:
     if input_path == "-":
@@ -175,7 +185,13 @@ def cmd_score(args: argparse.Namespace) -> int:
         chunk_weight=args.chunk_weight,
         chunk_attention_tau=args.chunk_attention_tau,
     )
-    df = fb.score(text)
+    df = fb.score(
+        text,
+        explain_tokens=args.explain_tokens,
+        explain_top_k=args.explain_top_k,
+        explain_max_tokens=args.explain_max_tokens,
+        explain_stride=args.explain_stride,
+    )
 
     fmt = args.format.lower()
     if fmt == "csv":
@@ -326,6 +342,14 @@ def build_parser() -> argparse.ArgumentParser:
                         help="Interpolation weight for chunk scores (segment=document).")
         sp.add_argument("--chunk-attention-tau", type=float, default=0.1,
                         help="Attention pooling temperature for chunks (segment=document).")
+        sp.add_argument("--explain-tokens", action="store_true",
+                        help="Include token-level importance scores in score output.")
+        sp.add_argument("--explain-top-k", type=int, default=None,
+                        help="Limit token explanations to top-k by absolute impact (requires --explain-tokens).")
+        sp.add_argument("--explain-max-tokens", type=int, default=None,
+                        help="Sample at most N tokens for explanation (requires --explain-tokens).")
+        sp.add_argument("--explain-stride", type=int, default=None,
+                        help="Sample every Nth token for explanation (requires --explain-tokens).")
 
     sp_score = sub.add_parser("score", help="Score segments and output per-segment data.")
     add_common(sp_score)

--- a/src/fabula/scorer.py
+++ b/src/fabula/scorer.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
+import math
 from typing import Dict, Iterable, List, Optional, Sequence
 
 
@@ -134,6 +135,72 @@ class TransformersScorer:
                     results.append(self._row_to_dict(row))
 
         return results
+
+    def explain_tokens(
+        self,
+        text: str,
+        target_label: Optional[str] = None,
+        top_k: Optional[int] = None,
+        max_tokens: Optional[int] = None,
+        stride: Optional[int] = None,
+    ) -> List[Dict[str, object]]:
+        if not text:
+            return []
+
+        enc = self.tokenizer(
+            text,
+            return_offsets_mapping=True,
+            add_special_tokens=True,
+        )
+        offsets = enc.get("offset_mapping", [])
+        input_ids = enc.get("input_ids", [])
+        if not offsets or not input_ids:
+            return []
+
+        tokens = self.tokenizer.convert_ids_to_tokens(input_ids)
+        base_probs = self.predict_proba([text])[0]
+        if not base_probs:
+            return []
+
+        if target_label is None:
+            target_label = max(base_probs.items(), key=lambda kv: kv[1])[0]
+
+        base_prob = float(base_probs.get(target_label, 0.0))
+
+        candidates = []
+        for token, (start, end) in zip(tokens, offsets):
+            if start is None or end is None or start == end:
+                continue
+            candidates.append((token, int(start), int(end)))
+
+        if not candidates:
+            return []
+
+        if stride is not None and stride > 1:
+            candidates = candidates[::stride]
+        if max_tokens is not None and max_tokens > 0 and len(candidates) > max_tokens:
+            step = max(1, math.ceil(len(candidates) / max_tokens))
+            candidates = candidates[::step]
+
+        texts = [text[:start] + text[end:] for _, start, end in candidates]
+        alt_probs = self.predict_proba(texts)
+
+        impacts = []
+        for (token, start, end), probs in zip(candidates, alt_probs):
+            new_prob = float(probs.get(target_label, 0.0)) if probs else 0.0
+            impacts.append(
+                {
+                    "token": token,
+                    "start_char": start,
+                    "end_char": end,
+                    "delta": base_prob - new_prob,
+                }
+            )
+
+        impacts.sort(key=lambda item: abs(float(item["delta"])), reverse=True)
+        if top_k is not None:
+            impacts = impacts[:max(0, int(top_k))]
+        return impacts
 
 
 def valence_from_probs(probs: Dict[str, float]) -> Optional[float]:


### PR DESCRIPTION
### Motivation
- Reduce the compute cost of token-level leave-one-out explanations by sampling which tokens are evaluated.  
- Expose sampling controls so consumers can trade explanation fidelity for speed via the API and CLI.  
- Surface per-segment interpretability metadata alongside existing outputs for easier inspection.  

### Description
- Extend `TransformersScorer.explain_tokens` with `max_tokens` and `stride` and implement sampling (stride-based subsampling and uniform downsampling to respect `max_tokens`).  
- Add `_interpret_probs` and extend `Fabula.score` to include `top_label`, `top_prob`, `second_label`, `second_prob`, `margin`, and `entropy`, and to accept and forward `explain_max_tokens`/`explain_stride` to token explanations.  
- Add CLI flags `--explain-max-tokens` and `--explain-stride` and plumb them through `cmd_score` to `Fabula.score`.  
- Update the `DummyScorer.explain_tokens` stub to match the new signature (`max_tokens`/`stride`).  

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69624882a35083228061cdc78dab9b7f)