### PR TITLE
Rename document segmentation mode to in-context

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Fabula is a Python package for analyzing how sentiment or emotions evolve across
 ## Key capabilities
 
 - **Per-segment scoring** for sentiment or emotion analysis.
-- **Multiple segmentation strategies** (sentence, paragraph, token windows, document chunks).
-- **Long-input handling** with chunk pooling and document-level interpolation.
+- **Multiple segmentation strategies** (sentence, paragraph, token windows, in-context chunks).
+- **Long-input handling** with chunk pooling and in-context interpolation.
 - **Narrative arc generation** with resampling + smoothing.
 - **CLI and Python API** for batch runs and scripting.
 
@@ -114,13 +114,13 @@ Uses the tokenizer to create overlapping windows. Requires a Transformers tokeni
 fabula score my.txt --segment window --window-tokens 256 --stride-tokens 64 --min-tokens 16
 ```
 
-### 4) Document chunking + interpolation
+### 4) In-context chunking + interpolation
 
 Scores sentences *and* coarse chunks, then blends their probabilities to preserve long-range context. Requires a tokenizer with offset mappings.
 
 ```bash
 fabula score my.txt \
-  --segment document \
+  --segment in-context \
   --chunk-tokens 1024 \
   --chunk-stride-tokens 1024 \
   --chunk-min-tokens 128 \
@@ -248,9 +248,9 @@ Each row includes:
 - `label`: top predicted label
 - `score`: scalar score for arcs
 - `probs`: full label distribution
-- `chunk_probs`: pooled chunk distribution (document mode only)
+- `chunk_probs`: pooled chunk distribution (in-context mode only)
 - `start_char`, `end_char`: character offsets (when available)
-- `start_token`, `end_token`: token offsets (window/document modes)
+- `start_token`, `end_token`: token offsets (window/in-context modes)
 
 ### `fabula arc`
 
@@ -279,9 +279,9 @@ The CLI has two subcommands: `score` and `arc`. Both share common options.
 - `--max-length`: max tokens per segment
 - `--pooling`: `none`, `mean`, `max`, `attention`
 - `--pooling-stride-tokens`: stride for pooled chunking (defaults to `max_length/4`)
-- `--segment`: `sentence`, `paragraph`, `window`, `document`
+- `--segment`: `sentence`, `paragraph`, `window`, `in-context`
 - `--window-tokens`, `--stride-tokens`, `--min-tokens`: window segmentation controls
-- `--chunk-tokens`, `--chunk-stride-tokens`, `--chunk-min-tokens`: document chunking controls
+- `--chunk-tokens`, `--chunk-stride-tokens`, `--chunk-min-tokens`: in-context chunking controls
 - `--chunk-weight`: interpolation weight for chunk scores
 - `--chunk-attention-tau`: attention pooling temperature for chunk scores
 
@@ -356,7 +356,7 @@ fabula arc my.txt --analysis emotion --score-col probs --format csv
 ### Long document, fewer API calls
 
 ```bash
-fabula score my.txt --segment document --chunk-tokens 2048 --chunk-weight 0.4
+fabula score my.txt --segment in-context --chunk-tokens 2048 --chunk-weight 0.4
 ```
 
 ### Smoke-test without downloading models
@@ -368,8 +368,8 @@ fabula score my.txt --dummy --analysis sentiment
 ## Notes & limitations
 
 - The default models are French. For other languages, pass a different Hugging Face model.
-- `window` and `document` segmentation require a Transformers tokenizer (disable `--dummy`).
-- `document` segmentation requires a tokenizer that returns offset mappings.
+- `window` and `in-context` segmentation require a Transformers tokenizer (disable `--dummy`).
+- `in-context` segmentation requires a tokenizer that returns offset mappings.
 - `score` outputs `score=None` when the model labels do not support valence; `arc` can fall back to max probability unless disabled.
 
 ## License

--- a/src/fabula/cli.py
+++ b/src/fabula/cli.py
@@ -135,9 +135,9 @@ def _make_segmenters(
             stride_tokens=stride_tokens,
             min_tokens=min_tokens,
         ), None
-    if kind == "document":
+    if kind == "in-context":
         if scorer_or_none is None or getattr(scorer_or_none, "tokenizer", None) is None:
-            raise ValueError("Document chunking requires a transformers tokenizer (disable --dummy).")
+            raise ValueError("In-context chunking requires a transformers tokenizer (disable --dummy).")
         return RegexSentenceSegmenter(), DocumentChunkTokenSegmenter(
             tokenizer=scorer_or_none.tokenizer,
             chunk_tokens=chunk_tokens,
@@ -328,20 +328,20 @@ def build_parser() -> argparse.ArgumentParser:
         sp.add_argument("--pooling-stride-tokens", type=int, default=None,
                         help="Stride for pooled chunking (default: max_length/4).")
 
-        sp.add_argument("--segment", choices=["sentence", "paragraph", "window", "document"], default="sentence",
+        sp.add_argument("--segment", choices=["sentence", "paragraph", "window", "in-context"], default="sentence",
                         help="Segmentation strategy (default: sentence).")
         sp.add_argument("--window-tokens", type=int, default=256, help="Token window size (segment=window).")
         sp.add_argument("--stride-tokens", type=int, default=64, help="Token stride (segment=window).")
         sp.add_argument("--min-tokens", type=int, default=16, help="Min tokens for window segments.")
-        sp.add_argument("--chunk-tokens", type=int, default=1024, help="Chunk token size (segment=document).")
+        sp.add_argument("--chunk-tokens", type=int, default=1024, help="Chunk token size (segment=in-context).")
         sp.add_argument("--chunk-stride-tokens", type=int, default=1024,
-                        help="Chunk stride (segment=document).")
+                        help="Chunk stride (segment=in-context).")
         sp.add_argument("--chunk-min-tokens", type=int, default=128,
-                        help="Min tokens for document chunks (segment=document).")
+                        help="Min tokens for in-context chunks (segment=in-context).")
         sp.add_argument("--chunk-weight", type=float, default=0.3,
-                        help="Interpolation weight for chunk scores (segment=document).")
+                        help="Interpolation weight for chunk scores (segment=in-context).")
         sp.add_argument("--chunk-attention-tau", type=float, default=0.1,
-                        help="Attention pooling temperature for chunks (segment=document).")
+                        help="Attention pooling temperature for chunks (segment=in-context).")
         sp.add_argument("--explain-tokens", action="store_true",
                         help="Include token-level importance scores in score output.")
         sp.add_argument("--explain-top-k", type=int, default=None,

--- a/src/fabula/segment.py
+++ b/src/fabula/segment.py
@@ -172,7 +172,7 @@ class DocumentChunkTokenSegmenter:
         input_ids: Sequence[int] = enc["input_ids"]
         offsets = enc.get("offset_mapping")
         if offsets is None:
-            raise ValueError("Tokenizer must provide offsets for document chunking.")
+            raise ValueError("Tokenizer must provide offsets for in-context chunking.")
 
         n_tokens = len(input_ids)
         if n_tokens == 0:


### PR DESCRIPTION
### Motivation

- Clarify the segmentation mode name by renaming `document` to `in-context` to better reflect that coarse chunks provide long-range context for sentence scoring.
- Align CLI choices, help text, error messages, and documentation to the new naming for consistency.
- Preserve the existing chunking behavior while updating the external name used in the API and CLI.

### Description

- Change the CLI segment choice from `document` to `in-context` and update the `_make_segmenters` branch to check `kind == "in-context"` in `src/fabula/cli.py`.
- Update related CLI help strings and flag descriptions (e.g. `--chunk-tokens`, `--chunk-stride-tokens`, `--chunk-min-tokens`, `--chunk-weight`, `--chunk-attention-tau`) to reference `in-context` in `src/fabula/cli.py`.
- Update error messages that referenced document chunking to say `in-context` in `src/fabula/cli.py` and `src/fabula/segment.py` (the `DocumentChunkTokenSegmenter` offset check message).
- Update `README.md` examples, the CLI reference, and output format documentation to use `in-context` and to adjust notes about `chunk_probs` and token/offset fields.

### Testing

- No automated tests were run.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69624f81a06c832292679b790fba2719)